### PR TITLE
JCenter() -> MavenCentral()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	repositories {
-		jcenter()
+		mavenCentral()
 		maven {
 			name = 'forge'
 			url = 'https://files.minecraftforge.net/maven'
@@ -38,7 +38,7 @@ minecraft {
 }
 
 repositories {
-	jcenter()
+	mavenCentral()
     mavenCentral()
 
 	maven {

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ minecraft {
 }
 
 repositories {
-	mavenCentral()
     mavenCentral()
 
 	maven {


### PR DESCRIPTION
Due to JCenter() not being supported 2 months ago (February 1st 2022), no one really updated it :( 